### PR TITLE
Restoring old pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,77 +1,10 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.282"
     hooks:
-    - id: check-docstring-first
-    - id: check-added-large-files
-      args: ['--maxkb=1000']
-    - id: check-merge-conflict
-    - id: check-toml
-    - id: check-yaml
-    - id: debug-statements
-    - id: end-of-file-fixer
-    - id: requirements-txt-fixer
-    - id: trailing-whitespace
+      - id: ruff
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v2.29.1
-  hooks:
-  - id: pyupgrade
-    args: [--py38-plus]
-
-- repo: https://github.com/psf/black
-  rev: 22.3.0
-  hooks:
-  - id: black
-    args: ["--config=pyproject.toml"]
-    files: "(openweb_proxy)"
-
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-  - id: isort
-    args: ["--settings-path=pyproject.toml"]
-    files: "(openweb_proxy)"
-
-- repo: https://github.com/pycqa/bandit
-  rev: 1.7.1
-  hooks:
-  - id: bandit
-    language: python
-    language_version: python3
-    types: [python]
-    args: ["-c", "pyproject.toml"]
-    additional_dependencies: ["toml"]
-    files: "(openweb_proxy)"
-
-- repo: https://github.com/PyCQA/flake8
-  rev: 5.0.1
-  hooks:
-   - id: flake8
-     additional_dependencies: [
-       flake8-typing-imports==1.14.0,
-       flake8-pyproject==1.1.0.post0
-     ]
-
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910-1
-  hooks:
-  - id: mypy
-    args: ["--ignore-missing-imports"]
-    files: "(openweb_proxy)"
-
-- repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.5.3
-  hooks:
-    - id: nbqa-black
-    - id: nbqa-pyupgrade
-      args: [--py37-plus]
-    - id: nbqa-isort
-      args: ['--profile=black']
-    - id: nbqa-flake8
-
-- repo: https://github.com/jorisroovers/gitlint
-  rev: v0.18.0
-  hooks:
-    - id: gitlint
-    - id: gitlint-ci
+  - repo: https://github.com/psf/black
+    rev: "23.7.0"
+    hooks:
+      - id: black


### PR DESCRIPTION
We can add more pre-commit as needed in the future.

Current pre-commit uses
* [ruff](https://github.com/astral-sh/ruff-pre-commit)
* [black](https://github.com/psf/black)